### PR TITLE
Replace outdated baseUrl with publicPath

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  baseUrl: process.env.NODE_ENV === 'production'
+  publicPath: process.env.NODE_ENV === 'production'
       ? `${process.cwd()}/dist/`
       : '/'
 }


### PR DESCRIPTION
Update vue.config.js.

baseUrl is out dated and replaced with publicPath. 

@see https://github.com/vuejs/vue-cli/issues/5162#issuecomment-583729967